### PR TITLE
feat: mouse movement added

### DIFF
--- a/includes/cub.h
+++ b/includes/cub.h
@@ -28,6 +28,10 @@
  * the length from the proj_plane vector is 0.66
  */
 # define PROJ_PLANE_LEN 0.66
+/* mouse bounds of camera movement */
+# define MS_L_RANGE 0.375
+# define MS_R_RANGE 0.625
+
 
 /* OS CHECK */
 # ifdef APPLE
@@ -122,6 +126,13 @@ typedef struct s_keys {
 	int right;
 }	t_keys;
 
+typedef struct s_mouse
+	{
+	double left;
+	double right;
+}	t_mouse;;
+
+
 typedef struct s_cub {
 	/* minilibx */
 	void		*mlx;
@@ -158,6 +169,7 @@ typedef struct s_cub {
 	int			draw_end;
 	/* movement */
 	t_keys		keys;
+	t_mouse		mouse;
 	/* draw navigator */
 	t_img		*nav_img;
 }				t_cub;
@@ -188,6 +200,9 @@ int		check_args(int ac, char **av);
 t_pair_d		*init_pair_double(t_cub *cub);
 t_pair_i		*init_pair_int(t_cub *cub);
 t_cub			init_cub(void);
+/* INIT HOOKS */
+void	init_keys(t_cub *cub);
+void	init_mouse(t_cub *cub);
 /* INIT PARSE */
 t_parse_info	init_parse_info(void);
 /* INIT MLX and everything that needs it */
@@ -229,6 +244,7 @@ int		update_display(t_cub *cub);
 /* KEY HOOKS */
 int	key_up(int keycode, t_cub *cub);
 int	key_down(int keycode, t_cub *cub);
+int	mouse_hook(int x, int y, t_cub *cub);
 /* MOVEMENT */
 void	move_forward(t_cub *cub, double edge, double move_speed);
 void	move_backward(t_cub *cub, double edge, double move_speed);

--- a/srcs/hooks/key_hooks.c
+++ b/srcs/hooks/key_hooks.c
@@ -43,3 +43,24 @@ int	key_down(int keycode, t_cub *cub)
 		graceful_exit(cub);
 	return (0);
 }
+
+int	mouse_hook(int x, int y, t_cub *cub)
+{
+	(void)y;
+	if (x > MS_L_RANGE * WIDTH && x < MS_R_RANGE * WIDTH)
+	{
+		cub->mouse.left = 0;
+		cub->mouse.right = 0;
+	}
+	else if (x < MS_L_RANGE * WIDTH)
+	{
+		cub->mouse.left = fabs(MS_L_RANGE * WIDTH - x);
+		cub->mouse.right = 0;
+	}
+	else if (x > MS_R_RANGE * WIDTH)
+	{
+		cub->mouse.left = 0;
+		cub->mouse.right = fabs(MS_R_RANGE * WIDTH - x);
+	}
+	return (0);
+}

--- a/srcs/initializers/init_cub.c
+++ b/srcs/initializers/init_cub.c
@@ -42,18 +42,6 @@ static void	init_raycast_vars(t_cub *cub)
 	cub->draw_end = 0;
 }
 
-static void	init_keys(t_cub *cub)
-{
-	cub->keys.w = 0;
-	cub->keys.a = 0;
-	cub->keys.s = 0;
-	cub->keys.d = 0;
-	cub->keys.up = 0;
-	cub->keys.down = 0;
-	cub->keys.left = 0;
-	cub->keys.right = 0;
-}
-
 t_cub	init_cub(void)
 {
 	t_cub	cub;
@@ -75,6 +63,7 @@ t_cub	init_cub(void)
 	cub.map_width = 0;
 	init_raycast_vars(&cub);
 	init_keys(&cub);
+	init_mouse(&cub);
 	cub.nav_img = NULL;
 	return (cub);
 }

--- a/srcs/initializers/init_hooks.c
+++ b/srcs/initializers/init_hooks.c
@@ -1,0 +1,19 @@
+#include "cub.h"
+
+void	init_keys(t_cub *cub)
+{
+	cub->keys.w = 0;
+	cub->keys.a = 0;
+	cub->keys.s = 0;
+	cub->keys.d = 0;
+	cub->keys.up = 0;
+	cub->keys.down = 0;
+	cub->keys.left = 0;
+	cub->keys.right = 0;
+}
+
+void	init_mouse(t_cub *cub)
+{
+	cub->mouse.left = 0;
+	cub->mouse.right = 0;
+}

--- a/srcs/main.c
+++ b/srcs/main.c
@@ -15,6 +15,7 @@ int	main(int ac, char **av)
 	render(&cub);
 	mlx_hook(cub.window, 3, 1L << 1, key_up, &cub);
 	mlx_hook(cub.window, 2, 1L << 0, key_down, &cub);
+	mlx_hook(cub.window, 6, 1L << 6, mouse_hook, &cub);
 	mlx_hook(cub.window, 17, 0, graceful_exit, &cub);
 	mlx_loop_hook(cub.mlx, update_display, &cub);
 	mlx_loop(cub.mlx);

--- a/srcs/render/render.c
+++ b/srcs/render/render.c
@@ -9,18 +9,15 @@ void	render(t_cub *cub)
 /*
 	UPDATE_DISPLAY:
 	-	Inside of mlx_loop_hook, so happening when NO event happens
-	-	Checks the key value in the relevant struct set by key_down and key_up
+	-	Checks the key value in the relevant struct set by key_down, key_up and
+		mouse_hook
 	-	If values in the struct are non-zero, apply movement to coords
 
-	-	VAR: Edge detection = 1.1]
-	-	VAR: Movement Speed = 0.05 squares/frame]
-	-	VAR: Rotation Speed = 0.02 radians]
+	-	VAR: Edge detection = checks if map exists 10% beyond next square (1.1)
+	-	VAR: Movement Speed = squares/frame (MOVE_SPEED macro)
+	-	VAR: Rotation Speed = radians/frame (ROT_SPEED macro)
 
-	-	Above values were set by experimentation. We can also change the
-		static int frame value in the if statement
-
-	-	Frametime: need to establish some values here that make the project
-		run smoothly accross both Macs and Linux. Currently in milliseconds
+	-	Above values were set by experimentation for both MacOS and Linux.
 */
 int	update_display(t_cub *cub)
 {
@@ -32,13 +29,17 @@ int	update_display(t_cub *cub)
 		rotate_left(cub, ROT_SPEED);
 	else if (cub->keys.right)
 		rotate_right(cub, ROT_SPEED);
+	if (cub->mouse.left)
+		rotate_left(cub, ROT_SPEED * cub->mouse.left / WIDTH);
+	else if (cub->mouse.right)
+		rotate_right(cub, ROT_SPEED * cub->mouse.right / WIDTH);
 	if (cub->keys.a)
 		move_left(cub, 1.1, MOVE_SPEED);
 	else if (cub->keys.d)
 		move_right(cub, 1.1, MOVE_SPEED);
 	if (cub->keys.w || cub->keys.a || cub->keys.s || cub->keys.d
 		|| cub->keys.up || cub->keys.down || cub->keys.left
-		|| cub->keys.right)
+		|| cub->keys.right || cub->mouse.left || cub->mouse.right)
 		render(cub);
 	return (0);
 }


### PR DESCRIPTION
New feature added: mouse_movement.

Some comments:
1. Mouse movement does not happen in the range 0.375 to 0.625. Without this, the screen keeps always rotating unless the mouse is centered right in the middle exactly. I thought this was a good range, but can be adjusted. These values are defined as macros in the header file.
2. Init_cub.c was getting too big (too many functions) so I made a file called init_hooks() for both keys and mouse. Alternatively, we could rename init_keys to something else and add to there.