### PR TITLE
Parser spaces

### DIFF
--- a/includes/cub.h
+++ b/includes/cub.h
@@ -225,8 +225,9 @@ void	validate_map_info(t_cub *cub, t_parse_info* parse_info);
 /* PARSER COLOR and TEXTURE */
 int		textures_colors_not_set(t_cub *cub, t_parse_info *parse_info);
 int		texture_or_color_is_valid(t_cub *cub, t_parse_info	*parse_info);
-/* PARSER MAP */
+/* PARSER MAP 1*/
 void	evaluate_map_size(t_cub *cub, t_parse_info* parse_info);
+/* PARSER MAP 2*/
 void	validate_map_grid(t_cub *cub, t_parse_info* parse_info);
 void	set_player(t_cub *cub, char player, int x, int y);
 /* PARSER UTILS */

--- a/includes/cub.h
+++ b/includes/cub.h
@@ -189,15 +189,14 @@ typedef struct s_parse_info {
 	char	*buff;
 	int		ret;
 	int		line_nb;
-	char	*line_trimmed;
-	char	**line_content;
+	char	*line;
 	char	*prefix;
 	int		prefix_len;
+	char	*content;
 	char	**colors;
 	int		*colors_rgb;
 	int		is_floor_color_set;
 	int		is_ceil_color_set;
-	char	*file_name;
 	int		line_nb_map_start;
 	size_t	max_map_width;
 	int		is_player_set;
@@ -233,6 +232,8 @@ void	set_player(t_cub *cub, char player, int x, int y);
 /* PARSER UTILS */
 int		line_is_empty(char *line);
 char	*replace_tab_with_spaces(char *line);
+char	*ft_strreplace(char *org, char *old_set, char new_set);
+void	split_prefix_from_content(t_parse_info *parse_info);
 
 /* *** RENDER *** */
 /* PIXEL PUT */
@@ -297,6 +298,7 @@ int		get_g(int trgb);
 int		get_b(int trgb);
 /* DEBUG */
 void	print_cub(t_cub *cub);
+void	print_split(char **split);
 /* FPS */
 unsigned long long	get_time_micros(void);
 void				display_fps(t_cub *cub);

--- a/maps/subject.cub
+++ b/maps/subject.cub
@@ -1,9 +1,9 @@
 NO ./textures/north_texture.xpm
-SO ./textures/south_texture.xpm
-WE ./textures/west_texture.xpm
-EA ./textures/east_texture.xpm
+SO ./textures/south_texture.xpm   
+       WE  ./textures/west_texture.xpm
+  EA   ./textures/east_texture.xpm
 
-F 30,232,0
+F 	30 , 232 , 0
 C 142,211,255
 
         1111111111111111111111111

--- a/srcs/dev/debug.c
+++ b/srcs/dev/debug.c
@@ -27,3 +27,16 @@ void	print_cub(t_cub *cub)
 	printf("Direction (x, y) = (%.2f, %.2f)\n", cub->dir->x, cub->dir->y);
 	printf("\n");
 }
+
+void	print_split(char **split)
+{
+	int	i;
+
+	i = 0;
+	while (split[i])
+	{
+		printf("%s ", split[i]);
+		i++;
+	}
+	printf("\n");
+}

--- a/srcs/initializers/init_parse.c
+++ b/srcs/initializers/init_parse.c
@@ -9,14 +9,14 @@ t_parse_info	*init_parse_info(void)
 	parse_info->buff = NULL;
 	parse_info->ret = 0;
 	parse_info->line_nb = 1;
-	parse_info->line_content = NULL;
+	parse_info->line = NULL;
 	parse_info->prefix = NULL;
 	parse_info->prefix_len = 0;
+	parse_info->content = NULL;
 	parse_info->colors = NULL;
 	parse_info->colors_rgb = NULL;
 	parse_info->is_floor_color_set = 0;
 	parse_info->is_ceil_color_set = 0;
-	parse_info->file_name = NULL;
 	parse_info->line_nb_map_start = 0;
 	parse_info->max_map_width = 0;
 	parse_info->is_player_set = 0;

--- a/srcs/initializers/singletons.c
+++ b/srcs/initializers/singletons.c
@@ -27,6 +27,9 @@ t_parse_info	*get_parse_info(t_parse_info *parse_info, int clear)
 	if (!parse_info_ptr && parse_info)
 		parse_info_ptr = parse_info;
 	if (clear)
+	{
+		free(parse_info_ptr);
 		parse_info_ptr = NULL;
+	}
 	return (parse_info_ptr);
 }

--- a/srcs/parser/parser.c
+++ b/srcs/parser/parser.c
@@ -23,8 +23,8 @@ void	validate_map_info(t_cub *cub, t_parse_info* parse_info)
 			free(parse_info->buff);
 			continue ;
 		}
-		parse_info->line_trimmed = ft_strtrim(parse_info->buff, "\t\v\f\r ");
-		parse_info->line_content = ft_split(parse_info->line_trimmed, ' ');
+		parse_info->line = ft_strreplace(parse_info->buff, "\t\v\f\r", ' ');
+		split_prefix_from_content(parse_info);
 		if (!texture_or_color_is_valid(cub, parse_info))
 			error_and_exit(MAP_TEXT_COLOR_INCORRECT);
 		parse_info->line_nb++;

--- a/srcs/parser/parser_color_texture.c
+++ b/srcs/parser/parser_color_texture.c
@@ -50,9 +50,9 @@ static int	color_is_valid(t_cub *cub, t_parse_info *parse_info, char *content)
 	if (!color_values_are_valid(parse_info))
 		return (0);
 	if ((ft_strncmp(parse_info->prefix, "F", 1) == 0 &&
-		parse_info->is_f_color_set) ||
+		parse_info->is_floor_color_set) ||
 		(ft_strncmp(parse_info->prefix, "C", 1) == 0 &&
-		parse_info->is_c_color_set))
+		parse_info->is_ceil_color_set))
 		return (0);
 	if (ft_strncmp(parse_info->prefix, "F", 1) == 0)
 	{

--- a/srcs/parser/parser_color_texture.c
+++ b/srcs/parser/parser_color_texture.c
@@ -2,21 +2,28 @@
 
 int	textures_colors_not_set(t_cub *cub, t_parse_info *parse_info)
 {
-	return (cub->walls[NO].path == NULL || cub->walls[SO].path == NULL || cub->walls[WE].path == NULL ||
-		cub->walls[EA].path == NULL || parse_info->is_floor_color_set == 0 ||
+	return (cub->walls[NO].path == NULL || cub->walls[SO].path == NULL ||
+		cub->walls[WE].path == NULL || cub->walls[EA].path == NULL ||
+		parse_info->is_floor_color_set == 0 ||
 		parse_info->is_ceil_color_set == 0);
 }
 
 static int	color_values_are_valid(t_parse_info *parse_info)
 {
-	int	i;
+	int		i;
+	char	*color_trimmed;
 
 	i = 0;
 	while (i < 3)
 	{
-		if (!is_number(parse_info->colors[i]))
+		color_trimmed = ft_strtrim(parse_info->colors[i], "\t\v\f\r ");
+		if (!is_number(color_trimmed))
+		{
+			free(color_trimmed);
 			return (0);
-		parse_info->colors_rgb[i] = ft_atoi(parse_info->colors[i]);
+		}
+		parse_info->colors_rgb[i] = ft_atoi(color_trimmed);
+		free(color_trimmed);
 		if (parse_info->colors_rgb[i] < 0 || parse_info->colors_rgb[i] > 255)
 			return (0);
 		i++;
@@ -43,9 +50,9 @@ static int	color_is_valid(t_cub *cub, t_parse_info *parse_info, char *content)
 	if (!color_values_are_valid(parse_info))
 		return (0);
 	if ((ft_strncmp(parse_info->prefix, "F", 1) == 0 &&
-		parse_info->is_floor_color_set) ||
+		parse_info->is_f_color_set) ||
 		(ft_strncmp(parse_info->prefix, "C", 1) == 0 &&
-		parse_info->is_ceil_color_set))
+		parse_info->is_c_color_set))
 		return (0);
 	if (ft_strncmp(parse_info->prefix, "F", 1) == 0)
 	{
@@ -66,15 +73,13 @@ static int	color_is_valid(t_cub *cub, t_parse_info *parse_info, char *content)
  * - checks the files exists/can be opened
  * - makes sure this texture hadn't been defined already
  */
-static int	texture_is_valid(t_cub *cub, t_parse_info *parse_info,
-				char *content)
+static int	texture_is_valid(t_cub *cub, t_parse_info *parse_info)
 {
 	int		fd;
 
-	parse_info->file_name = ft_strtrim(content, "\t\n\v\f\r ");
-	if (!has_right_file_ext(parse_info->file_name, "xpm"))
+	if (!has_right_file_ext(parse_info->content, "xpm"))
 		return (0);
-	if ((fd = open(parse_info->file_name, O_RDONLY)) == -1)
+	if ((fd = open(parse_info->content, O_RDONLY)) == -1)
 		return (error_and_return(FILE_INEXISTENT, 0));
 	if ((ft_strncmp(parse_info->prefix, "NO", 2) == 0 && cub->walls[NO].path) ||
 		(ft_strncmp(parse_info->prefix, "SO", 2) == 0 && cub->walls[SO].path) ||
@@ -82,21 +87,19 @@ static int	texture_is_valid(t_cub *cub, t_parse_info *parse_info,
 		(ft_strncmp(parse_info->prefix, "EA", 2) == 0 && cub->walls[EA].path))
 		return (0);
 	if (ft_strncmp(parse_info->prefix, "NO", 2) == 0)
-		cub->walls[NO].path = ft_strdup(parse_info->file_name);
+		cub->walls[NO].path = ft_strdup(parse_info->content);
 	else if (ft_strncmp(parse_info->prefix, "SO", 2) == 0)
-		cub->walls[SO].path = ft_strdup(parse_info->file_name);
+		cub->walls[SO].path = ft_strdup(parse_info->content);
 	else if (ft_strncmp(parse_info->prefix, "WE", 2) == 0)
-		cub->walls[WE].path = ft_strdup(parse_info->file_name);
+		cub->walls[WE].path = ft_strdup(parse_info->content);
 	else
-		cub->walls[EA].path = ft_strdup(parse_info->file_name);
+		cub->walls[EA].path = ft_strdup(parse_info->content);
 	close_or_exit(fd);
 	return (1);
 }
 
 /*
  * Checks if the texture or color information is valid and stores it
- * - after prefix there might be white spaces -> accomodates for that
- * - if after the prefix there is no more information, it's not valid
  * - checks if prefix is correct
  * - checks if it's a color and if it's valid
  * - checks it it's a texture and if it's valid
@@ -110,23 +113,17 @@ int	texture_or_color_is_valid(t_cub *cub, t_parse_info	*parse_info)
 
 	i = 1;
 	is_valid = 0;
-	while (line_is_empty(parse_info->line_content[i]))
-		i++;
-	if (!parse_info->line_content[i])
+	if (parse_info->prefix_len == 0 || ft_strlen(parse_info->content) == 0)
 		return (0);
-	parse_info->prefix = ft_strtrim(parse_info->line_content[0], "\t\v\f\r ");
-	parse_info->prefix_len = ft_strlen(parse_info->prefix);
 	if ((ft_strncmp(parse_info->prefix, "F", 1) == 0 ||
 			ft_strncmp(parse_info->prefix, "C", 1) == 0) &&
 			parse_info->prefix_len == 1)
-		is_valid = color_is_valid(cub, parse_info, parse_info->line_content[i]);
+		is_valid = color_is_valid(cub, parse_info, parse_info->content);
 	if ((ft_strncmp(parse_info->prefix, "NO", 2) == 0 ||
 			ft_strncmp(parse_info->prefix, "SO", 2) == 0 ||
 			ft_strncmp(parse_info->prefix, "WE", 2) == 0 ||
 			ft_strncmp(parse_info->prefix, "EA", 2) == 0) &&
 			parse_info->prefix_len == 2)
-		is_valid = texture_is_valid(cub, parse_info, parse_info->line_content[i]);
-	if (i + 1 != ft_split_len(parse_info->line_content))
-		return (0);
+		is_valid = texture_is_valid(cub, parse_info);
 	return (is_valid);
 }

--- a/srcs/parser/parser_color_texture.c
+++ b/srcs/parser/parser_color_texture.c
@@ -108,10 +108,8 @@ static int	texture_is_valid(t_cub *cub, t_parse_info *parse_info)
  */
 int	texture_or_color_is_valid(t_cub *cub, t_parse_info	*parse_info)
 {
-	int	i;
 	int	is_valid;
 
-	i = 1;
 	is_valid = 0;
 	if (parse_info->prefix_len == 0 || ft_strlen(parse_info->content) == 0)
 		return (0);

--- a/srcs/parser/parser_map.c
+++ b/srcs/parser/parser_map.c
@@ -23,6 +23,7 @@ void	evaluate_map_size(t_cub *cub, t_parse_info* parse_info)
 		parse_info->buff = replace_tab_with_spaces(parse_info->buff);
 		if (ft_strlen(parse_info->buff) > parse_info->max_map_width)
 			parse_info->max_map_width = ft_strlen(parse_info->buff);
+		free(parse_info->buff); // right? 26 lines :(
 		parse_info->line_nb++;
 	}
 	while ((parse_info->ret = get_next_line(cub->map_fd, &parse_info->buff)) > 0)

--- a/srcs/parser/parser_map_1.c
+++ b/srcs/parser/parser_map_1.c
@@ -1,0 +1,37 @@
+#include "cub.h"
+
+static void	evaluate_map_line_size(t_parse_info *parse_info)
+{
+	parse_info->buff = replace_tab_with_spaces(parse_info->buff);
+	if (ft_strlen(parse_info->buff) > parse_info->max_map_width)
+		parse_info->max_map_width = ft_strlen(parse_info->buff);
+	parse_info->line_nb++;
+}
+
+/* Goes through the map for the first time and checks its height and width,
+ * so later the appropriate memory can be allocated.
+ * need to go until the end of the file, else it won't restart properly
+ */
+void	evaluate_map_size(t_cub *cub, t_parse_info* parse_info)
+{
+	parse_info->line_nb_map_start = parse_info->line_nb;
+	while (parse_info->ret > 0 && !line_is_empty(parse_info->buff))
+	{
+		evaluate_map_line_size(parse_info);
+		free(parse_info->buff);
+		parse_info->ret = get_next_line(cub->map_fd, &parse_info->buff);
+	}
+	if (parse_info->ret == -1)
+		error_and_exit(READ_FAIL);
+	if (!line_is_empty(parse_info->buff))
+		evaluate_map_line_size(parse_info);
+	free(parse_info->buff);
+	if (parse_info->ret > 0)
+	{
+		while ((parse_info->ret = get_next_line(cub->map_fd, &parse_info->buff)) > 0)
+			free(parse_info->buff);
+		free(parse_info->buff);
+	}
+	cub->map_height = parse_info->line_nb - parse_info->line_nb_map_start;
+	cub->map_width = parse_info->max_map_width;
+}

--- a/srcs/parser/parser_map_2.c
+++ b/srcs/parser/parser_map_2.c
@@ -1,38 +1,5 @@
 #include "cub.h"
 
-/* Goes through the map for the first time and checks its height and width,
- * so later the appropriate memory can be allocated.
- * need to go until the end of the file, else it won't restart properly
- */
-void	evaluate_map_size(t_cub *cub, t_parse_info* parse_info)
-{
-	parse_info->line_nb_map_start = parse_info->line_nb;
-	while (parse_info->ret > 0 && !line_is_empty(parse_info->buff))
-	{
-		parse_info->buff = replace_tab_with_spaces(parse_info->buff);
-		if (ft_strlen(parse_info->buff) > parse_info->max_map_width)
-			parse_info->max_map_width = ft_strlen(parse_info->buff);
-		free(parse_info->buff);
-		parse_info->ret = get_next_line(cub->map_fd, &parse_info->buff);
-		parse_info->line_nb++;
-	}
-	if (parse_info->ret == -1)
-		error_and_exit(READ_FAIL);
-	if (!line_is_empty(parse_info->buff))
-	{
-		parse_info->buff = replace_tab_with_spaces(parse_info->buff);
-		if (ft_strlen(parse_info->buff) > parse_info->max_map_width)
-			parse_info->max_map_width = ft_strlen(parse_info->buff);
-		free(parse_info->buff); // right? 26 lines :(
-		parse_info->line_nb++;
-	}
-	while ((parse_info->ret = get_next_line(cub->map_fd, &parse_info->buff)) > 0)
-		free(parse_info->buff);
-	free(parse_info->buff);
-	cub->map_height = parse_info->line_nb - parse_info->line_nb_map_start;
-	cub->map_width = parse_info->max_map_width;
-}
-
 /* Sets player's initial position and direction */
 void	set_player(t_cub *cub, char player, int x, int y)
 {

--- a/srcs/parser/parser_utils.c
+++ b/srcs/parser/parser_utils.c
@@ -19,7 +19,9 @@ int	line_is_empty(char *line)
 	return (1);
 }
 
-/* Replaces 1 tab for 4 spaces */
+/* REPLACE TAB w SPACES
+ * Replaces 1 tab for 4 spaces - the usual configuration
+ */
 char	*replace_tab_with_spaces(char *line)
 {
 	int		tab_nb;
@@ -47,4 +49,74 @@ char	*replace_tab_with_spaces(char *line)
 	}
 	free(line);
 	return (repl);
+}
+
+/* STR_REPLACE
+ * replaces any character from a given set for another one.
+ * used to replace all forms of white space for a space,
+ * to simplify the parsing
+ */
+static int	belongs_to_set(char *set, char c)
+{
+	while (*set)
+	{
+		if (*set == c)
+			return (1);
+		set++;
+	}
+	return (0);
+}
+
+char	*ft_strreplace(char *org, char *old_set, char new_set)
+{
+	char	*replaced;
+	int		i;
+
+	if (!org || !old_set)
+		return (NULL);
+	replaced = (char *)calloc_or_exit(sizeof(char), ft_strlen(org) + 1);
+	i = 0;
+	while (org[i])
+	{
+		if (belongs_to_set(old_set, org[i]))
+			replaced[i] = new_set;
+		else
+			replaced[i] = org[i];
+		i++;
+	}
+	return (replaced);
+}
+
+/* SPLIT PREFIX from CONTENT
+ * note that ft_strlcpy returns the length of source, thus the end of line
+ * if things go wrong, prefix and content will both be empty freeable strings
+ * for prefix, i points to the start and j at end;
+ * for content, j points to the start and i at end (it required less code)
+ */
+void	split_prefix_from_content(t_parse_info *parse_info)
+{
+	int	i;
+	int	j;
+
+	i = 0;
+	while (parse_info->line[i] && parse_info->line[i] == ' ')
+		i++;
+	j = i;
+	while (parse_info->line[j] && parse_info->line[j] != ' ')
+		j++;
+	parse_info->prefix = (char *)calloc_or_exit(sizeof(char), j - i + 1);
+	parse_info->prefix_len = j - i;
+	ft_strlcpy(parse_info->prefix, parse_info->line + i, j - i + 1);
+	while (parse_info->line[j] && parse_info->line[j] == ' ')
+		j++;
+	i = ft_strlen(parse_info->line);
+	while (parse_info->line[i - 1] && parse_info->line[i - 1] == ' ')
+		i--;
+	if (i < j)
+	{
+		parse_info->content = ft_strdup("");
+		return ;
+	}
+	parse_info->content = (char *)calloc_or_exit(sizeof(char), i - j + 1);
+	ft_strlcpy(parse_info->content, parse_info->line + j, i - j + 1);
 }

--- a/srcs/terminate/free_memory.c
+++ b/srcs/terminate/free_memory.c
@@ -82,22 +82,19 @@ void	free_parse_info(t_parse_info *parse_info)
 	if (parse_info->buff)
 		free(parse_info->buff);
 	parse_info->buff = NULL;
-	if (parse_info->line_trimmed)
-		free(parse_info->line_trimmed);
-	parse_info->line_trimmed = NULL;
-	if (parse_info->line_content)
-		free_split(parse_info->line_content);
-	parse_info->line_content = NULL;
+	if (parse_info->line)
+		free(parse_info->line);
+	parse_info->line = NULL;
 	if (parse_info->prefix)
 		free(parse_info->prefix);
 	parse_info->prefix = NULL;
+	if (parse_info->content)
+		free(parse_info->content);
+	parse_info->content = NULL;
 	if (parse_info->colors)
 		free_split(parse_info->colors);
 	parse_info->colors = NULL;
 	if (parse_info->colors_rgb)
 		free(parse_info->colors_rgb);
 	parse_info->colors_rgb = NULL;
-	if (parse_info->file_name)
-		free(parse_info->file_name);
-	parse_info->file_name = NULL;
 }


### PR DESCRIPTION
main changes:
- how parser deals with spaces: replace all kinds of white spaces for spaces to make it easier (no need for trimming so much afterwards) and instead of using split, I just separate the prefix from the content by the spaces and work from there
- tried to fix the leak, although honestly at some point I was getting double frees I have no clue as to why... very confusing
( I will still need to do some changes for norminette)